### PR TITLE
Added switch case to differentiate between LW and FLW in Decoder.cpp,…

### DIFF
--- a/Lab04/Decoder.cpp
+++ b/Lab04/Decoder.cpp
@@ -77,6 +77,9 @@ void Decoder::process(uint32_t input){
                  << "'" << endl;
             this->printCtrl();
         break;
+        case OPCODE_FR: //instruction is FP R-type
+
+        break;
         case OPCODE_I: //instruction is I-type
             this->rfctrl.selrs1   = i.I.rs1; //get RS1 from i
             this->rfctrl.selrd    = i.I.rd;  //get RD  from i
@@ -156,20 +159,10 @@ void Decoder::process(uint32_t input){
                     cout << "LH";
                 break;
                 case F3_LW:
-                    switch(i.I.opcode){
-                        case OP_lw:
-                            this->memctrl.memrsgn = 1;   //enable sign-extension
-                            this->memctrl.memrsz  = 0b11;//Word size
-                            cout << "LW";
-                        break;
-                        case OP_flw:
-                            // TODO
-                            // Make flag for determining which register file to use (this instruction needs FP register file)
-                            this->rfctrl.selrf = 1;     //set flag to take registers from FP register file
-                            this->memctrl.memrsz = 0b11;//Word size
-                        break;
-                    }
-                break;    
+                    this->memctrl.memrsgn = 1;   //enable sign-extension
+                    this->memctrl.memrsz  = 0b11;//Word size
+                    cout << "LW";
+                break;
             }
             cout << " X" << this->rfctrl.selrd
                  << ",X" << this->rfctrl.selrs1
@@ -177,6 +170,8 @@ void Decoder::process(uint32_t input){
                  << "]'" << endl;
             this->printCtrl();
         break;
+        case OPCODE_FL: //instruction is FP-Load type
+            // TODO
         case OPCODE_S: //instruction is S-type
             this->rfctrl.selrs1   = i.S.rs1; //get RS1 from i
             this->rfctrl.selrs2   = i.S.rs2; //get RD  from i
@@ -202,6 +197,9 @@ void Decoder::process(uint32_t input){
                  << "[" << immSignExtendShift(this->immctrl.value,this->immctrl.immsize,this->immctrl.immshft)
                  << "]'" << endl;
             this->printCtrl();
+        break;
+        case OPCODE_FS: //instruction is FP S-type
+
         break;
         case OPCODE_B: //instruction is B-type
             this->rfctrl.selrs1   = i.B.rs1; //get RS1 from i

--- a/Lab04/Decoder.cpp
+++ b/Lab04/Decoder.cpp
@@ -156,10 +156,20 @@ void Decoder::process(uint32_t input){
                     cout << "LH";
                 break;
                 case F3_LW:
-                    this->memctrl.memrsgn = 1;   //enable sign-extension
-                    this->memctrl.memrsz  = 0b11;//Word size
-                    cout << "LW";
-                break;
+                    switch(i.I.opcode){
+                        case OP_lw:
+                            this->memctrl.memrsgn = 1;   //enable sign-extension
+                            this->memctrl.memrsz  = 0b11;//Word size
+                            cout << "LW";
+                        break;
+                        case OP_flw:
+                            // TODO
+                            // Make flag for determining which register file to use (this instruction needs FP register file)
+                            this->rfctrl.selrf = 1;     //set flag to take registers from FP register file
+                            this->memctrl.memrsz = 0b11;//Word size
+                        break;
+                    }
+                break;    
             }
             cout << " X" << this->rfctrl.selrd
                  << ",X" << this->rfctrl.selrs1

--- a/Lab04/Decoder.cpp
+++ b/Lab04/Decoder.cpp
@@ -78,14 +78,29 @@ void Decoder::process(uint32_t input){
             this->printCtrl();
         break;
         case OPCODE_FR: //instruction is FP R-type
-
+            this->rfctrl.selrs1 = i.R.rs1; //get RS1 from i
+            this->rfctrl.selrs2 = i.R.rs2; //get RS2 from i
+            this->rfctrl.selrd  = i.R.rd;  //get RD  from i
+            this->rfctrl.rfwen  = 1;       //enable RF Writeback
+            this->rfctrl.r1flop = 1;       //enable FP register for r1
+            this->rfctrl.r2flop = 1;       //enable FP register for r2
+            this->rfctrl.rdflop = 1;       //enable FP register for rd
+            this->aluctrl.alufp = 1;       //enable ALU FP operation
+            cout << "Decoded :: R-Type Instruction\n Instruction: '";
+            switch(i.I.funct3){
+                case F3_ADD: //FADD or FSUB
+                    this->aluctrl.aluop = (i.R.funct7 == 0)?(ALU_ADD):(ALU_SUB);
+                    if(i.R.funct7==0){cout << "ADD";}
+                    else {cout <<"SUB";}
+                break;
+            }
         break;
         case OPCODE_I: //instruction is I-type
             this->rfctrl.selrs1   = i.I.rs1; //get RS1 from i
             this->rfctrl.selrd    = i.I.rd;  //get RD  from i
             this->rfctrl.rfwen    = 1;       //enable RF Writeback
             this->aluctrl.alubsel = 1;       //set ALU B SRC to immediate
-            this->immctrl.value = (i.I.im11_5<<5) | i.I.im4_0; //imm[11:0]
+            this->immctrl.value   = (i.I.im11_5<<5) | i.I.im4_0; //imm[11:0]
             cout << "Decoded :: I-Type Instruction\n Instruction: '";
             switch(i.I.funct3){//Determine ALUOP from funct3, funct7
                 case F3_ADD: //ADDI or SUBI
@@ -135,7 +150,7 @@ void Decoder::process(uint32_t input){
             this->rfctrl.selrd    = i.I.rd;  //get RD  from i
             this->rfctrl.rfwen    = 1;       //enable RF Writeback
             this->aluctrl.alubsel = 1;       //set ALU B SRC to immediate
-            this->immctrl.value = (i.I.im11_5<<5) | i.I.im4_0; //imm[11:0]
+            this->immctrl.value   = (i.I.im11_5<<5) | i.I.im4_0; //imm[11:0]
             cout << "Decoded :: I-Type Instruction\n Instruction: '";
             switch(i.I.funct3){ //determine sign-extension and shift amount by funct3
                 case F3_LBU:
@@ -172,11 +187,32 @@ void Decoder::process(uint32_t input){
         break;
         case OPCODE_FL: //instruction is FP-Load type
             // TODO
+            this->rfctrl.selrs1   = i.I.rs1; //get RS1 from i
+            this->rfctrl.selrd    = i.I.rd;  //get RD  from i
+            this->rfctrl.rfwen    = 1;       //enable RF Writeback
+            this->rfctrl.r1flop   = 1;       //enable FP register for r1
+            this->rfctrl.rdflop   = 1;       //enable FP register for rd
+            this->aluctrl.alubsel = 1;       //set ALU B SRC to immediate
+            this->immctrl.value   = (i.I.im11_5<<5) | i.I.im4_0; //imm[11:0]
+            cout << "Decoded :: I-Type Instruction\n Instruction: '";
+            switch(i.I.funct3){ //determine sign-extension and shift amount by funct3
+                case F3_LW:
+                    this->memctrl.memrsgn = 1;   //enable sign-extension
+                    this->memctrl.memrsz  = 0b11;//Word size
+                    cout << "FLW";
+                break;
+            }
+            cout << " X" << this->rfctrl.selrd
+                 << ",X" << this->rfctrl.selrs1
+                 << "[" << immSignExtendShift(this->immctrl.value,this->immctrl.immsize,this->immctrl.immshft)
+                 << "]'" << endl;
+            this->printCtrl();
+        break;
         case OPCODE_S: //instruction is S-type
             this->rfctrl.selrs1   = i.S.rs1; //get RS1 from i
             this->rfctrl.selrs2   = i.S.rs2; //get RD  from i
             this->aluctrl.alubsel = 1;       //set ALU B SRC to immediate
-            this->immctrl.value = (i.S.im11_5<<5) | i.S.im4_0; //imm[11:0]->imm[11:0]
+            this->immctrl.value   = (i.S.im11_5<<5) | i.S.im4_0; //imm[11:0]->imm[11:0]
             cout << "Decoded :: S-Type Instruction\n Instruction: '";
             switch(i.S.funct3){ //determine sign-extension and shift amount by funct3
                 case F3_SB:
@@ -199,7 +235,24 @@ void Decoder::process(uint32_t input){
             this->printCtrl();
         break;
         case OPCODE_FS: //instruction is FP S-type
-
+            this->rfctrl.selrs1   = i.S.rs1; //get RS1 from i
+            this->rfctrl.selrs2   = i.S.rs2; //get RS2  from i
+            this->rfctrl.r1flop   = 1;       //enable FP register for r1
+            this->rfctrl.r2flop   = 1;       //enable FP register for r2
+            this->aluctrl.alubsel = 1;       //set ALU B SRC to immediate
+            this->immctrl.value   = (i.S.im11_5<<5) | i.S.im4_0; //imm[11:0]->imm[11:0]
+            cout << "Decoded :: S-Type Instruction\n Instruction: '";
+            switch(i.S.funct3){ //determine sign-extension and shift amount by funct3
+                case F3_SW:
+                    this->memctrl.memwsz  = 0b11;//Word size
+                    cout << "SW";
+                break;
+            }
+            cout << " X" << this->rfctrl.selrs2
+                 << ",X" << this->rfctrl.selrs1
+                 << "[" << immSignExtendShift(this->immctrl.value,this->immctrl.immsize,this->immctrl.immshft)
+                 << "]'" << endl;
+            this->printCtrl();
         break;
         case OPCODE_B: //instruction is B-type
             this->rfctrl.selrs1   = i.B.rs1; //get RS1 from i

--- a/Lab04/Decoder.h
+++ b/Lab04/Decoder.h
@@ -44,6 +44,7 @@ class Decoder{
             uint16_t  selrs2 : 5; //select RS2        |
             uint16_t   selrd : 5; //select RD         |  
             uint16_t   rfwen : 1; //enable write to RD| 0:disable, 1:enable
+            uint16_t   selrf : 1; //select reg file   | 0:integer, 1:float
             uint16_t:0;//union alignment
         };
     } rfctrl; //Register File Control Signals

--- a/Lab04/Decoder.h
+++ b/Lab04/Decoder.h
@@ -44,7 +44,9 @@ class Decoder{
             uint16_t  selrs2 : 5; //select RS2        |
             uint16_t   selrd : 5; //select RD         |  
             uint16_t   rfwen : 1; //enable write to RD| 0:disable, 1:enable
-            uint16_t   selrf : 1; //select reg file   | 0:integer, 1:float
+            uint16_t  r1flop : 1; //ctrlPort : Select floating-point register for rs1
+            uint16_t  r2flop : 1; //ctrlPort : Select floating-point register for rs2
+            uint16_t  rdflop : 1; //ctrlPort : Select floating-point register for rd
             uint16_t:0;//union alignment
         };
     } rfctrl; //Register File Control Signals
@@ -56,6 +58,7 @@ class Decoder{
             uint8_t alucomp : 2; //select ALU Comparison Type|
             uint8_t aluasel : 1; //select ALU A Source       | 0:RS1, 1:PC
             uint8_t alubsel : 1; //select ALU B Source       | 0:RS2, 1:Immediate
+            uint8_t   alufp : 1; //select ALU FP Operation   | 0:i,   1:float
             uint8_t:0;//union alignment
         };
     } aluctrl;//ALU Control Signals

--- a/Lab04/RISCV.h
+++ b/Lab04/RISCV.h
@@ -146,9 +146,12 @@
 //Defined Decoding Opcodes
 //--------------------------------------------
 #define OPCODE_R 0x33
+#define OPCODE_FR 0x53
 #define OPCODE_I 0x13
 #define OPCODE_L 0x03
+#define OPCODE_FL 0x07
 #define OPCODE_S 0x23
+#define OPCODE_FS 0x27
 #define OPCODE_B 0x63
 #define OPCODE_LUI 0x37
 #define OPCODE_AUIPC 0x17


### PR DESCRIPTION
… which led to adding selrf as a flag in the rfctrl flags withint Decoder.h

Wanted to review if this is how it should work in the decoder for FLW, I may be missing some other flags to set for the instruction, but I wanted to check if this is where these flags should be set. 